### PR TITLE
Locate bash using /usr/bin/env

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###
 ### A configuration script for Sawja


### PR DESCRIPTION
Not all systems install bash at /bin/bash. Most notably, some BSD systems don't ship bash as the default shell, and do not install third-party packages in /bin (they go in /usr/local/bin instead).

Use `/usr/bin/env` so that bash is automatically located, wherever it may be.

With this change, the package now builds properly on OpenBSD.