### PR TITLE
Sawja plugin

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -145,7 +145,7 @@ Options:
 #
 # The option parsing function. Uses getopts, a bash built-in function.
 #
-while getopts "d:b:l:hv" opt
+while getopts "d:b:l:hvs" opt
 do
   case $opt in 
     h   ) print_usage

--- a/sawja.opam
+++ b/sawja.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/javalib-team/sawja/issues"
 license: "GPL-3.0-or-later"
 dev-repo: "git+https://github.com/javalib-team/sawja.git"
 build: [
-  ["./configure.sh"]
+  ["./configure.sh" "-s" { ocaml:native-dynlink } ]
   [make]
 ]
 install: [

--- a/src/Makefile
+++ b/src/Makefile
@@ -141,8 +141,8 @@ sawja.cma: sawja_pack.cmo
 sawja.cmxa: sawja_pack.cmx
 	$(OCAMLOPT) -a -o $@ $^
 
-# sawja.cmxs: sawja.cmxa
-# 	$(OCAMLOPT) -shared -o $@ $^
+sawja.cmxs: sawja.cmxa
+	$(OCAMLOPT) -shared -o $@ $^
 
 sawja_pack.cmo: $(MODULE_INTERFACES:=.cmi) $(MODULES:=.cmo)
 	$(OCAMLC) -pack $(MODULES:=.cmo) -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -141,7 +141,7 @@ sawja.cma: sawja_pack.cmo
 sawja.cmxa: sawja_pack.cmx
 	$(OCAMLOPT) -a -o $@ $^
 
-sawja.cmxs: sawja.cmxa
+sawja.cmxs: sawja_pack.cmx
 	$(OCAMLOPT) -shared -o $@ $^
 
 sawja_pack.cmo: $(MODULE_INTERFACES:=.cmi) $(MODULES:=.cmo)

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,7 @@ META: META.source ../Makefile.config
 		echo "plugin(native) = \"$(SHARED)\"" >> $@; \
 	fi
 
-install: META sawja.cma sawja.cmxa $(MODULE_INTERFACES:=.mli) sawja_pack.cmi sawja_pack.cmo sawja_pack.cmx sawja_pack.o 
+install: META sawja.cma sawja.cmxa $(SHARED) $(MODULE_INTERFACES:=.mli) sawja_pack.cmi sawja_pack.cmo sawja_pack.cmx sawja_pack.o 
 	$(INSTALL) sawja $^ bir.cmi sawja.a
 
 remove:

--- a/src/Makefile
+++ b/src/Makefile
@@ -79,6 +79,9 @@ META: META.source ../Makefile.config
 	else \
 		$(SED) 's/requires = "javalib"/requires = "javalib"/' $< > $@ ; \
 	fi
+	if [ -n "$(SHARED)" ]; then \
+		echo "plugin(native) = \"$(SHARED)\"" >> $@; \
+	fi
 
 install: META sawja.cma sawja.cmxa $(MODULE_INTERFACES:=.mli) sawja_pack.cmi sawja_pack.cmo sawja_pack.cmx sawja_pack.o 
 	$(INSTALL) sawja $^ bir.cmi sawja.a


### PR DESCRIPTION
Allows having a usable `sawja.cmxs` as a plug-in from `ocamlfind`:

- make `-s` option in `./configure.sh` usable
- update `Makefile` directives for generating and installing `sawja.cmxs`
- update `META` file in presence of `-s`
- instruct `opam` to configure with `-s` if the compiler has native dynlink enabled