### PR TITLE
Use Stdlib instead of Pervasives

### DIFF
--- a/jvmti/trace_native/NativeStubsGen.annot
+++ b/jvmti/trace_native/NativeStubsGen.annot
@@ -73,7 +73,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -88,7 +88,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -103,7 +103,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -339,7 +339,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -354,7 +354,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -369,7 +369,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -605,7 +605,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -620,7 +620,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -635,7 +635,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -871,7 +871,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -886,7 +886,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -901,7 +901,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -1137,7 +1137,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -1152,7 +1152,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -1167,7 +1167,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -1469,7 +1469,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -1484,7 +1484,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -1676,7 +1676,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   Genlex.token option
@@ -1755,7 +1755,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -1770,7 +1770,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -1785,7 +1785,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -2021,7 +2021,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -2036,7 +2036,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -2051,7 +2051,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -2320,7 +2320,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t ref
 )
 ident(
-  ext_ref Pervasives.ref
+  ext_ref Stdlib.ref
 )
 "NativeStubsGen.ml" 55 2137 2160 "NativeStubsGen.ml" 55 2137 2175
 type(
@@ -2425,7 +2425,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   Sawja_pack.JNativeStubs.native_method_info
@@ -2443,7 +2443,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -2458,7 +2458,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -2710,7 +2710,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.( ! )
+  ext_ref Stdlib.( ! )
 )
 "NativeStubsGen.ml" 66 2526 2533 "NativeStubsGen.ml" 66 2526 2572
 call(
@@ -2802,7 +2802,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.( ! )
+  ext_ref Stdlib.( ! )
 )
 "NativeStubsGen.ml" 69 2622 2640 "NativeStubsGen.ml" 69 2622 2680
 call(
@@ -2823,7 +2823,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t -> unit
 )
 ident(
-  ext_ref Pervasives.( := )
+  ext_ref Stdlib.( := )
 )
 "NativeStubsGen.ml" 70 2682 2684 "NativeStubsGen.ml" 70 2682 2685
 type(
@@ -3123,7 +3123,7 @@ type(
   string -> string -> bool
 )
 ident(
-  ext_ref Pervasives.( = )
+  ext_ref Stdlib.( = )
 )
 "NativeStubsGen.ml" 85 3155 3212 "NativeStubsGen.ml" 85 3155 3220
 type(
@@ -3502,7 +3502,7 @@ type(
   string -> string -> bool
 )
 ident(
-  ext_ref Pervasives.( = )
+  ext_ref Stdlib.( = )
 )
 "NativeStubsGen.ml" 105 3961 4004 "NativeStubsGen.ml" 105 3961 4012
 type(
@@ -3702,7 +3702,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   Sawja_pack.JNativeStubs.native_method_info
@@ -3720,7 +3720,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -3735,7 +3735,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -3987,7 +3987,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.( ! )
+  ext_ref Stdlib.( ! )
 )
 "NativeStubsGen.ml" 115 4337 4344 "NativeStubsGen.ml" 115 4337 4383
 call(
@@ -4005,7 +4005,7 @@ type(
   string -> string Sawja_pack.JNativeStubs.StringMap.t Stack.t
 )
 ident(
-  ext_ref Pervasives.failwith
+  ext_ref Stdlib.failwith
 )
 "NativeStubsGen.ml" 116 4384 4408 "NativeStubsGen.ml" 116 4384 4442
 type(
@@ -4027,7 +4027,7 @@ type(
   string Sawja_pack.JNativeStubs.StringMap.t -> unit
 )
 ident(
-  ext_ref Pervasives.ignore
+  ext_ref Stdlib.ignore
 )
 "NativeStubsGen.ml" 117 4446 4459 "NativeStubsGen.ml" 117 4446 4468
 type(
@@ -4136,7 +4136,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   Sawja_pack.JNativeStubs.native_method_info
@@ -4154,7 +4154,7 @@ type(
   Sawja_pack.JNativeStubs.MethodMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   string Sawja_pack.JNativeStubs.StringMap.t
@@ -4169,7 +4169,7 @@ type(
   exn -> string Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.raise
+  ext_ref Stdlib.raise
 )
 type(
   unit
@@ -4421,7 +4421,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t
 )
 ident(
-  ext_ref Pervasives.( ! )
+  ext_ref Stdlib.( ! )
 )
 "NativeStubsGen.ml" 124 4675 4682 "NativeStubsGen.ml" 124 4675 4721
 call(
@@ -4439,7 +4439,7 @@ type(
   string -> string Sawja_pack.JNativeStubs.StringMap.t Stack.t
 )
 ident(
-  ext_ref Pervasives.failwith
+  ext_ref Stdlib.failwith
 )
 "NativeStubsGen.ml" 125 4722 4746 "NativeStubsGen.ml" 125 4722 4766
 type(
@@ -4516,7 +4516,7 @@ type(
   string -> string -> bool
 )
 ident(
-  ext_ref Pervasives.( = )
+  ext_ref Stdlib.( = )
 )
 "NativeStubsGen.ml" 127 4811 4859 "NativeStubsGen.ml" 127 4811 4867
 type(
@@ -5086,7 +5086,7 @@ type(
   string -> in_channel
 )
 ident(
-  ext_ref Pervasives.open_in
+  ext_ref Stdlib.open_in
 )
 "NativeStubsGen.ml" 152 5770 5789 "NativeStubsGen.ml" 152 5770 5793
 type(
@@ -5157,7 +5157,7 @@ type(
   Sawja_pack.JNativeStubs.StringMap.t -> unit
 )
 ident(
-  ext_ref Pervasives.( := )
+  ext_ref Stdlib.( := )
 )
 "NativeStubsGen.ml" 155 5873 5881 "NativeStubsGen.ml" 155 5873 5896
 type(
@@ -5227,7 +5227,7 @@ type(
   in_channel -> unit
 )
 ident(
-  ext_ref Pervasives.close_in
+  ext_ref Stdlib.close_in
 )
 "NativeStubsGen.ml" 157 5961 5976 "NativeStubsGen.ml" 157 5961 5978
 type(

--- a/sawja.opam
+++ b/sawja.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "sawja"
-version: "1.5.11"
+version: "1.5.12"
 maintainer: "sawja@inria.fr"
 authors: "Sawja development team"
 homepage: "http://sawja.inria.fr"
@@ -20,7 +20,7 @@ install: [
 depends: [
   "ocaml" {>= "4.08"}
   "ocamlfind" {build}
-  "javalib" {>= "3.2.1" & < "3.3"}
+  "javalib" {>= "3.2.2" & < "3.3"}
 ]
 
 synopsis: "Sawja provides a high level representation of Java bytecode programs and static analysis tools"

--- a/sawja.opam
+++ b/sawja.opam
@@ -18,7 +18,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.08"}
   "ocamlfind" {build}
   "javalib" {>= "3.2.1" & < "3.3"}
 ]

--- a/src/META.source
+++ b/src/META.source
@@ -1,4 +1,4 @@
-version = "1.5.10"
+version = "1.5.12"
 description = "Sawja helps you to manipulates Java bytecode programs"
 archive(native) = "sawja.cmxa"
 archive(byte) = "sawja.cma"

--- a/src/classDomainBDD.ml
+++ b/src/classDomainBDD.ml
@@ -48,7 +48,7 @@ module BddBuddy = struct
   let bdd_implies v1 v2 = Buddy.apply v1 v2 Buddy.IMP
 
   let equal = (=)
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 
   let ithvar _man i = Buddy.ithvar i
   let nithvar _man i = Buddy.nithvar i
@@ -78,7 +78,7 @@ end
 (*   let bdd_implies = Bdd.is_leq *)
 
 (*   let equal = (=) *)
-(*   let compare = Pervasives.compare *)
+(*   let compare = Stdlib.compare *)
 
 
 (*   let ithvar man v = Bdd.ithvar man v *)
@@ -159,7 +159,7 @@ open S
       if s1 <> s2 then assert false;
       s1
 
-  (* let compare = Pervasives.compare in *)
+  (* let compare = Stdlib.compare in *)
   let equal = (=)
 
   let elements : t -> int list =


### PR DESCRIPTION
Pervasives was deprecated in favor of directly using Stdlib in 4.08 and then removed in the upcoming 5.0. This change makes javalib buildable with the multi-core ocaml 5.0~alpha.

NOTE: I checked that the project builds with 5.0 but I didn't try to run anything. In particular I'm not sure what jvmti native stubs do.

A companion javalib PR is https://github.com/javalib-team/javalib/pull/22 (where the version is bumped to 3.2.2)